### PR TITLE
Add port type when list all gateway ports

### DIFF
--- a/open_vsdcli/vsdcli.py
+++ b/open_vsdcli/vsdcli.py
@@ -1185,11 +1185,12 @@ def port_list(ctx, filter, **ids):
         result = ctx.obj['nc'].get(request)
     else :
         result = ctx.obj['nc'].get(request, filter=filter)
-    table=PrettyTable(["ID", "name", "physicalName"])
+    table=PrettyTable(["ID", "name", "physicalName", "Type"])
     for line in result:
         table.add_row([line['ID'],
                        line['name'],
-                       line['physicalName'] ])
+                       line['physicalName'],
+                       line['portType'] ])
     print table
 
 


### PR DESCRIPTION

Output example:
```
$ vsd port-list --gateway-id 98141414-7c36-48f6-a552-17d9d70694ec
+--------------------------------------+--------+--------------+---------+
|                  ID                  |  name  | physicalName |   Type  |
+--------------------------------------+--------+--------------+---------+
| cf290448-3261-4668-9654-10eda1d39fca | 1/1/1  |    1/1/1     | NETWORK |
| f889bbf2-11d2-4ace-a93c-c30da993c412 | 1/1/10 |    1/1/10    | NETWORK |
| 5d245d63-38b9-47b6-97a2-947c63efffa7 | 1/1/11 |    1/1/11    | NETWORK |
| c42c602f-cb14-4f82-b10e-7cea20596821 | 1/1/12 |    1/1/12    | NETWORK |
| 10ede51a-36e3-4008-b9e2-9166c7ec86cc | 1/1/13 |    1/1/13    | NETWORK |
...
```