### PR TITLE
Add free-api command

### DIFF
--- a/open_vsdcli/vsdcli.py
+++ b/open_vsdcli/vsdcli.py
@@ -127,6 +127,47 @@ def me_show(ctx, verbose):
         print_object( result, exclude=['APIKey'], only=ctx.obj['show_only'] )
 
 
+@vsdcli.command(name='free-api')
+@click.argument('ressource', metavar='<ressource>', required=True)
+@click.option('--verb',
+              type=click.Choice(['PUT',
+                                 'GET',
+                                 'POST',
+                                 'DELETE']),
+              default='GET',
+              help='Default : GET')
+@click.option('--header', metavar='<name:value>', help='Add header to the request. Can be repeated.')
+@click.option('--key-value', metavar='<key:value>', multiple=True, help='Specify body in key/value pair. Can be repeated. Incompatible with --body.')
+@click.option('--body', metavar='<data json>', help='Specify body of the request in json format. Incompatible with --key-value.')
+@click.pass_context
+def free_api(ctx, ressource, verb, header, key_value, body):
+    """build your own API call (with headers and data)"""
+    import json
+    if key_value and body:
+        raise click.exceptions.UsageError(
+            "Use body or key-value")
+    if key_value:
+        params = {}
+        for kv in key_value:
+            key, value = kv.split(':',1)
+            params[key] = value
+    if body:
+        try:
+            params = json.loads(body)
+        except ValueError:
+            raise click.exceptions.UsageError(
+                "Body could not be decoded as JSON")
+    if verb == 'GET':
+        result = ctx.obj['nc'].get(ressource)
+    elif verb == 'PUT':
+        result = ctx.obj['nc'].put(ressource, params)
+    elif verb == 'POST':
+        result = ctx.obj['nc'].post(ressource, params)
+    elif verb == 'DELETE':
+        result = ctx.obj['nc'].delete(ressource)
+    print json.dumps(result, indent=4)
+
+
 @vsdcli.command(name='license-list')
 @click.pass_context
 def license_list(ctx):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 name = open-vsdcli
-version = 0.2.1
 author = Maxime Terras
 author_email = maxime.terras@numergy.com
 summary = CLI for Nuage VSD

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -181,6 +181,72 @@ setup() {
 }
 
 
+@test "free-api: use with non-existing verb" {
+    run vsd free-api enterprises --verb FALSE
+    assert_fail
+    assert_line_equals -1 'Error: Invalid value for "--verb": invalid choice: FALSE. (choose from PUT, GET, POST, DELETE)'
+}
+
+
+@test "free-api: list all enterprises (GET as default)" {
+    run vsd free-api enterprises
+    assert_success
+    assert_output_contains '"name": "nulab-update"'
+    assert_output_contains '"name": "nulab-2"'
+    assert_output_contains '"name": "new-enterprise"'
+}
+
+
+@test "free-api: list all enterprises with GET" {
+    run vsd free-api enterprises --verb GET
+    assert_success
+    assert_output_contains '"name": "nulab-update"'
+    assert_output_contains '"name": "nulab-2"'
+    assert_output_contains '"name": "new-enterprise"'
+}
+
+
+@test "free-api: delete enterprise with DELETE" {
+    run vsd free-api enterprises/255d9673-7281-43c4-be57-fdec677f6e07?responseChoice=1 --verb DELETE
+    assert_success
+    assert_line_equals 0 '{}'
+}
+
+
+@test "free-api: create enterprise with POST and key-value" {
+    run vsd free-api enterprises --verb POST --key-value 'name:enterpriseTest'
+    assert_success
+    assert_line_equals 0 '['
+    assert_line_equals 1 '    {'
+    assert_line_equals 2 '        "ID": "255d9673-7281-43c4-be57-fdec677f6e07", '
+    assert_line_equals 3 '        "description": "None", '
+    assert_line_equals 4 '        "name": "enterpriseTest"'
+    assert_line_equals 5 '    }'
+    assert_line_equals 6 ']'
+}
+
+
+@test "free-api: update enterprise with PUT and body" {
+    run vsd free-api enterprises/255d9673-7281-43c4-be57-fdec677f6e07 --verb PUT --body '[{ "name": "new-enterprise", "description": "Test" }]'
+    assert_success
+    assert_line_equals 0 '{}'
+}
+
+
+@test "free-api: body needs to be a valid JSON" {
+    run vsd free-api enterprises/255d9673-7281-43c4-be57-fdec677f6e07 --verb PUT --body '[{ "name": }]'
+    assert_fail
+    assert_line_equals -1 'Error: Body could not be decoded as JSON'
+}
+
+
+@test "free-api: key-value and body are incompatible" {
+    run vsd free-api enterprises --body '[{ "name":"test" }]' --key-value 'name:test'
+    assert_fail
+    assert_line_equals -1 'Error: Use body or key-value'
+}
+
+
 @test "License: create" {
     run vsd license-create 12Z1223E23E23E23E23E23OMEX2KEOJ3EPOJ2A3EPXJP34RJC4P5IOJVPOIYJECEOP4XJPRO4JC5SRVDCOTJQXZQJ4PCJT5P
     assert_success


### PR DESCRIPTION
Allow user to create arbitrary API call
Including url, body and headers

```
# vsd free-api --help
Usage: vsd free-api [OPTIONS] <ressource>

  build your own API call (with headers and data)

Options:
  --verb [PUT|GET|POST|DELETE]  Default : GET
  --header <name:value>         Add header to the request. Can be repeated.
  --key-value <key:value>       Specify body in key/value pair. Can be
                                repeated. Incompatible with --body.
  --body <data json>            Specify body of the request in json format.
                                Incompatible with --key-value.
  --help                        Show this message and exit.
```

Example:
```
# vsd free-api enterprises --verb GET
[
    {
        "allowedForwardingClasses": [
            "H"
        ], 
        "allowGatewayManagement": false, 
        "name": "nulab", 
        "allowAdvancedQOSConfiguration": false, 
        "avatarData": null, 
        "floatingIPsQuota": 16, 
        "owner": "f1b0850b-75c7-4a0d-a111-9f911ecb289b", 
        "ID": "a896a2f1-6ee3-40cf-ad34-d44e584dd3cd", 
        "avatarType": null, 
        "parentType": null, 
        "lastUpdatedBy": "8a6f0e20-a4db-4878-ad84-9cc61756cd5e", 
        "externalID": null, 
        "lastUpdatedDate": 1450714118000, 
        "parentID": null, 
        "allowTrustedForwardingClass": false, 
        "enterpriseProfileID": "f1e5eb19-c67a-4651-90c1-3f84e23e1d36", 
        "customerID": 10004, 
        "creationDate": 1447796769000, 
        "floatingIPsUsed": 0, 
        "children": null, 
        "description": "ttiti"
    }
]
```
And
```
# vsd free-api enterprises/a896a2f1-6ee3-40cf-ad34-d44e584dd3cd --verb PUT --key-value description:toto
[]
```
or
```
# vsd free-api enterprises/a896a2f1-6ee3-40cf-ad34-d44e584dd3cd --verb PUT --body '{"description": "t"}'
[]
```