### PR TITLE
Add creds

### DIFF
--- a/open_vsdcli/vsd_common.py
+++ b/open_vsdcli/vsd_common.py
@@ -87,7 +87,19 @@ def netmask_to_length(netmask):
     return str(length)
 
 
+def print_creds(ctx, param, value):
+    if not value or ctx.resilient_parsing:
+        return
+    click.echo('export VSD_USERNAME=<username>')
+    click.echo('export VSD_PASSWORD=<password>')
+    click.echo('export VSD_ORGANIZATION=csp')
+    click.echo('export VSD_URL=https://<host>:<port>/nuage/api/v3_0/')
+    ctx.exit()
+
+
 @click.group()
+@click.option('--creds', is_flag=True, callback=print_creds, is_eager=True,
+              expose_value=False, help='Display creds example')
 @click.option('--vsd-url', metavar='<url>', envvar='VSD_URL', required=True,
               help='VSD url http(s)://hostname:port/nuage/api_v1_0'
                    ' (Env: VSD_URL)')

--- a/tests/common.bash
+++ b/tests/common.bash
@@ -1,8 +1,5 @@
 APIKey=~/.vsd/APIKey
 
 setup() {
-    export VSD_USERNAME=test
-    export VSD_PASSWORD=test
-    export VSD_ORGANIZATION=test
-    export VSD_URL=http://localhost:5000/nuage/api/v1_0/
+  source creds-mock
 }

--- a/tests/creds-mock
+++ b/tests/creds-mock
@@ -1,0 +1,4 @@
+export VSD_USERNAME=test
+export VSD_PASSWORD=test
+export VSD_ORGANIZATION=test
+export VSD_URL=http://localhost:5000/nuage/api/v1_0/

--- a/tests/test_vsdcli.bats
+++ b/tests/test_vsdcli.bats
@@ -54,6 +54,16 @@ source common.bash
 }
 
 
+@test "VSD client: print creds example" {
+    run vsd --creds
+    assert_success
+    assert_output_contains "export VSD_USERNAME"
+    assert_output_contains "export VSD_PASSWORD"
+    assert_output_contains "export VSD_ORGANIZATION"
+    assert_output_contains "export VSD_URL"
+}
+
+
 @test "VSD client: request bag object" {
     run vsd enterprise-show bad-object
     assert_fail


### PR DESCRIPTION
for developpement, you can source mock creds and access the mock server (launch in other terminal)
```
source tests/creds-mock
vsd me-show
+--------------------+--------------------------------------+
| Field              |                Value                 |
+--------------------+--------------------------------------+
| ExpiryDecodeExpiry |       2016-07-25 12:00:00 UTC        |
| firstName          |               csproot                |
| APIKeyExpiry       |       2016-05-01 09:28:38 UTC        |
| enterpriseID       | fc3a351e-87dc-46a4-bcf5-8c4bb204bd46 |
| DateDecodeDate     |       2016-07-25 12:00:00 UTC        |
| enterpriseName     |                 CSP                  |
| DateNotDecode      |            1469448000000             |
+--------------------+--------------------------------------+
```

In addition, add a new command to show an example of the creds:
```
max$ vsd --creds
export VSD_USERNAME=<username>
export VSD_PASSWORD=<password>
export VSD_ORGANIZATION=csp
export VSD_URL=https://<host>:<port>/nuage/api/v3_0/
```