### PR TITLE
Fix #26 CLI not working with requests >= 2.11.1

### DIFF
--- a/open_vsdcli/vsd_client.py
+++ b/open_vsdcli/vsd_client.py
@@ -103,12 +103,13 @@ class VSDConnection(object):
         if filter:
             self.headers['X-Nuage-Filter'] = filter
         resp = []
-        self.headers['X-Nuage-Page'] = 0
+        X_Nuage_Page = 0
         while True:
+            self.headers['X-Nuage-Page'] = str(X_Nuage_Page)
             r = self._do_request('GET', self.base_url + url,
                                  headers=self.headers)
             resp += self._response(r)
-            self.headers['X-Nuage-Page'] += 1
+            X_Nuage_Page += 1
             if _next_page_is_invalid(r.headers):
                 break
         return resp


### PR DESCRIPTION
Requests version 2.11.1 and above does not allow anymore to use
integer for a value in the header json. All value need to be a
string.