### PR TITLE
Fix gateway redundancy groups creation without enterprise-id

### DIFF
--- a/open_vsdcli/vsd_gateway.py
+++ b/open_vsdcli/vsd_gateway.py
@@ -274,7 +274,7 @@ def gatewayredundancygroup_list(ctx, filter, enterprise_id):
 
 @vsdcli.command(name='gatewayredundancygroup-create')
 @click.argument('name', metavar='<name>', required=True)
-@click.option('--enterprise-id', metavar='<enterprise ID>', required=True)
+@click.option('--enterprise-id', metavar='<enterprise ID>')
 @click.option('--gateway-peer1-id', metavar='<gateway peer1 ID>',
               required=True)
 @click.option('--gateway-peer2-id', metavar='<gateway peer2 ID>',
@@ -287,8 +287,12 @@ def gatewayredundancygroup_create(ctx, name, enterprise_id,
     params = {'name':           name,
               'gatewayPeer1ID': gateway_peer1_id,
               'gatewayPeer2ID': gateway_peer2_id}
-    result = ctx.obj['nc'].post("enterprises/%s/redundancygroups" %
-                                enterprise_id, params)[0]
+    if enterprise_id:
+        url_request = "enterprises/%s/redundancygroups" % enterprise_id
+    else:
+        url_request = "redundancygroups"
+
+    result = ctx.obj['nc'].post(url_request, params)[0]
     print_object(result, only=ctx.obj['show_only'])
 
 

--- a/tests/test_redundancygroups.bats
+++ b/tests/test_redundancygroups.bats
@@ -44,6 +44,36 @@ source common.bash
     assert_output_contains_in_table systemID 2.2.2.2
     assert_output_contains_in_table ID 22222222-2222-2222-222222222222
 
+    run vsd gatewayredundancygroup-create gw-group \
+                       --gateway-peer1-id 11111111-1111-1111-111111111111 \
+                       --gateway-peer2-id 22222222-2222-2222-222222222222
+    assert_success
+    assert_output_contains_in_table name gw-group
+    assert_output_contains_in_table gatewayPeer1ID 11111111-1111-1111-111111111111
+    assert_output_contains_in_table gatewayPeer2ID 22222222-2222-2222-222222222222
+    assert_output_contains_in_table redundantGatewayStatus SUCCESS
+    assert_output_not_contains_in_table name gw-group-unknown
+}
+
+
+@test "VSD mock: reset" {
+    command vsd free-api reset
+}
+
+
+@test "Gateway redundant group: create (with enterprise-id)" {
+    run vsd gateway-create gateway-1 --system-id 1.1.1.1 --personality VRSG
+    assert_success
+    assert_output_contains_in_table name gateway-1
+    assert_output_contains_in_table systemID 1.1.1.1
+    assert_output_contains_in_table ID 11111111-1111-1111-111111111111
+
+    run vsd gateway-create gateway-2 --system-id 2.2.2.2 --personality VRSG
+    assert_success
+    assert_output_contains_in_table name gateway-2
+    assert_output_contains_in_table systemID 2.2.2.2
+    assert_output_contains_in_table ID 22222222-2222-2222-222222222222
+
     run vsd gatewayredundancygroup-create gw-group --enterprise-id fc3a351e-87dc-46a4-bcf5-8c4bb204bd46 \
                                                    --gateway-peer1-id 11111111-1111-1111-111111111111 \
                                                    --gateway-peer2-id 22222222-2222-2222-222222222222

--- a/tests/vsd_mock.py
+++ b/tests/vsd_mock.py
@@ -247,8 +247,49 @@ def gateway_create():
     return json.dumps([get_object_id('gateways', 'ID', id)])
 
 
+@app.route("/nuage/api/v1_0/redundancygroups", methods=['POST'])
+def gatewayredundantgroup_create():
+    data_update = json.loads(request.data)
+    if 'redundancygroups' not in database:
+        database.update({'redundancygroups': []})
+
+    id = get_object_id('redundancygroups', 'gatewayPeer1ID',
+                       data_update['gatewayPeer1ID'])
+    if id != {}:
+        return make_response(json.dumps(
+            get_object_id('messages', 'name', 'already in use')['message']), '409')
+
+    id = get_object_id('redundancygroups', 'gatewayPeer2ID',
+                       data_update['gatewayPeer2ID'])
+    if id != {}:
+        return make_response(json.dumps(
+            get_object_id('messages', 'name', 'already in use')['message']), '409')
+
+    id = '0'
+    for object in database['gateways']:
+        if (object['ID'][0] > id):
+            id = object['ID'][0]
+
+    id = increment_id(id)
+    new = {'ID': id,
+           'name': 'gw-group-unknown',
+           'description': 'None',
+           'entityScope': 'ENTERPRISE',
+           'enterpriseID': '76046673-d0ea-4a67-b6af-2829952f0812',
+           'gatewayPeer1ID': '11111111-1111-1111-111111111111',
+           'gatewayPeer2ID': '22222222-2222-2222-222222222222',
+           'gatewayPeer1Name': 'gateway-1',
+           'gatewayPeer2Name': 'gateway-2',
+           'redundantGatewayStatus': 'SUCCESS',
+           'personality': 'VRSG'}
+
+    new.update(data_update)
+    database['redundancygroups'].append(new)
+    return json.dumps([get_object_id('redundancygroups', 'ID', id)])
+
+
 @app.route("/nuage/api/v1_0/enterprises/<enterprise_id>/redundancygroups", methods=['POST'])
-def gatewayredundantgroup_create(enterprise_id):
+def gatewayredundantgroup_create_with_enterprise_id(enterprise_id):
     data_update = json.loads(request.data)
     if 'redundancygroups' not in database:
         database.update({'redundancygroups': []})


### PR DESCRIPTION
Numergy/openvsd#31

* Allow user to create redundant gateway at global or enterprise scope
* Add bats tests accordingly